### PR TITLE
feat(KK-11403): Improve exception handling to return descriptive error messages

### DIFF
--- a/app/services/create_pay_recipient_service.rb
+++ b/app/services/create_pay_recipient_service.rb
@@ -19,6 +19,18 @@ class CreatePayRecipientService < BaseService
     else
       CallResult.new(false, pay_recipient, pay_recipient.errors.full_messages)
     end
+  rescue K2ConnectRuby::K2Errors::TimeoutError => ex
+    logger.error("Timeout error when creating pay recipient: #{[ex.message, ex.backtrace].join("\n\t")}")
+    CallResult.new(false, nil, ex.message.to_s)
+  rescue K2ConnectRuby::K2Errors::UnauthorizedError => ex
+    logger.error("Unauthorized error when creating pay recipient: #{[ex.message, ex.backtrace].join("\n\t")}")
+    CallResult.new(false, nil, ex.message.to_s)
+  rescue K2ConnectRuby::K2Errors::ConnectionError => ex
+    logger.error("Connection error when creating pay recipient: #{[ex.message, ex.backtrace].join("\n\t")}")
+    CallResult.new(false, nil, ex.message.to_s)
+  rescue K2ConnectRuby::K2Errors::ApiError => ex
+    logger.error("API error when creating pay recipient: #{[ex.message, ex.code, ex.details, ex.backtrace].join("\n\t")}")
+    CallResult.new(false, nil, "API error: #{ex.message}, Code: #{ex.code}, Details: #{ex.details}")
   rescue StandardError => ex
     logger.error("Unexpected error when creating pay recipient: #{[ex.message, ex.backtrace].join("\n\t")}")
     CallResult.new(false, nil, "Unexpected error when creating pay recipient.")


### PR DESCRIPTION
This pull request improves error handling in the `CreatePayRecipientService` by adding specific rescue blocks for common K2ConnectRuby errors. This ensures that failures are logged with detailed information and that callers receive more informative error messages.

Enhanced error handling for pay recipient creation:

* Added rescue blocks for `TimeoutError`, `UnauthorizedError`, `ConnectionError`, and `ApiError` from `K2ConnectRuby::K2Errors`, each logging the error details and returning a `CallResult` with a descriptive error message. (`app/services/create_pay_recipient_service.rb`, [app/services/create_pay_recipient_service.rbR22-R33](diffhunk://#diff-c39f5e444acb727c075c34f287ca69d4edf842d2229b307a1f9f01dfdbf99279R22-R33))